### PR TITLE
Added github to dist metadata

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,9 +1,19 @@
 
-use ExtUtils::MakeMaker;
+use ExtUtils::MakeMaker 6.45;
 WriteMakefile(
               NAME            => 'Term::Pager',
               VERSION_FROM    => 'Pager.pm',
               ABSTRACT_FROM   => 'Pager.pm',
               AUTHOR          => 'Jeff Weisberg <http://www.tcp4me.com/>',
 	      PREREQ_PM       => {Term::Cap => 0},
+              META_MERGE      => {
+                                     'meta-spec' => { version => 2 },
+                                     resources => {
+                                         repository => {
+                                             type => 'git',
+                                             web  => 'https://github.com/jaw0/Term-Pager',
+                                             url  => 'https://github.com/jaw0/Term-Pager.git',
+                                         },
+                                     },
+                                 },
 );


### PR DESCRIPTION
Hi Jeff,

This change to the Makefile.PL makes the github repo appear in the distribution's metadata.

With this in place, metacpan.org will put a link to the repo in the sidebar, when people are looking at this module / distribution.

Cheers,
Neil